### PR TITLE
Eval Script Server Side

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -74,7 +74,7 @@ var ServiceNowSync = (function () {
                 }
             }
         });
-    }
+    };
 
     ServiceNowSync.prototype.compareFile = function (file) {
         let _this = this;
@@ -106,7 +106,7 @@ var ServiceNowSync = (function () {
                 }
             });
         }
-    }
+    };
 
     ServiceNowSync.prototype.enterConnectionSettings = function () {
         let _this = this;
@@ -115,6 +115,7 @@ var ServiceNowSync = (function () {
             password = '';
 
         let instancePromptOptions = {
+            "ingoreFocusOut": true,
             "prompt": "Enter the Instance URL",
             "validateInput": (val) => {
                 if (val == '') return 'Please enter a valid value.';
@@ -124,6 +125,7 @@ var ServiceNowSync = (function () {
         };
 
         let usernamePromptOptions = {
+            "ignoreFocusOut": true,
             "prompt": "Enter the Username",
             "validateInput": (val) => {
                 if (val == '') return 'Please enter a valid value.';
@@ -133,6 +135,7 @@ var ServiceNowSync = (function () {
         };
 
         let passwordPromptOptions = {
+            "ignoreFocusOut": true,
             "prompt": "Enter the Password",
             "password": true,
             "validateInput": (val) => {
@@ -156,24 +159,24 @@ var ServiceNowSync = (function () {
                 });
             });
         });
-    }
+    };
 
     ServiceNowSync.prototype.isSynced = function () {
         let rootFolder = vscode.workspace.workspaceFolders[0].uri._fsPath;
         let file = path.resolve(rootFolder, 'service-now.json');
         return fs.existsSync(file);
-    }
+    };
 
     ServiceNowSync.prototype.getRootSettings = function () {
         let _this = this;
         let rootFolder = vscode.workspace.workspaceFolders[0].uri._fsPath;
         return _this.readSettings(rootFolder);
-    }
+    };
 
     ServiceNowSync.prototype.isFolderSynced = function (folder) {
         let file = path.resolve(folder, 'service-now.json');
         return fs.existsSync(file);
-    }
+    };
 
     ServiceNowSync.prototype.createConnectionFile = function (params) {
         let _this = this;
@@ -200,7 +203,7 @@ var ServiceNowSync = (function () {
                 if (tableFieldList[table].length > 1) _this.createMultiFolder(table);
             }
         });
-    }
+    };
 
     ServiceNowSync.prototype.pullMultipleFiles = function (selectedFolder) {
         let _this = this;
@@ -216,7 +219,7 @@ var ServiceNowSync = (function () {
         vscode.window.showInputBox(queryPromptOptions).then(function (val) {
             _this.pullFile(selectedFolder, val);
         });
-    }
+    };
 
     ServiceNowSync.prototype.pullFile = function (selectedFolder, query) {
         let _this = this;
@@ -339,7 +342,7 @@ var ServiceNowSync = (function () {
             opn(rootSettings.instance + '/' + folderSettings.table + '.do?sys_id=' + sys_id);
         }
 
-    }
+    };
 
     ServiceNowSync.prototype.getRecord = function (settings, sys_id, cb) {
         let _this = this;
@@ -401,12 +404,12 @@ var ServiceNowSync = (function () {
             cb(null);
         }
 
-    }
+    };
 
     ServiceNowSync.prototype.writeSettings = function (folder, settings) {
         let file = path.resolve(folder, 'service-now.json');
         fs.writeFileSync(file, JSON.stringify(settings, false, 4));
-    }
+    };
 
     ServiceNowSync.prototype.readSettings = function (folder) {
         let file = path.resolve(folder, 'service-now.json');
@@ -421,7 +424,7 @@ var ServiceNowSync = (function () {
         }
         return false
 
-    }
+    };
 
     ServiceNowSync.prototype.createSingleFolder = function (table) {
         let _this = this;
@@ -441,7 +444,7 @@ var ServiceNowSync = (function () {
             _this.writeSettings(folderPath, folderSettings)
         }
 
-    }
+    };
 
     ServiceNowSync.prototype.createMultiFolder = function (table) {
         let _this = this;
@@ -474,8 +477,7 @@ var ServiceNowSync = (function () {
                 _this.writeSettings(subFolderPath, folderSettings);
             }
         });
-    }
-
+    };
 
     // ServiceNowSync.prototype.isFolderView = function () {
     //     return typeof vscode.workspace.workspaceFolders !== 'undefined';

--- a/extension.js
+++ b/extension.js
@@ -354,10 +354,10 @@ var ServiceNowSync = (function () {
             fields = _.uniq(fields);
         }
 
-        if (typeof query === 'undefined') {
-            _this.listRecords(settings.table, fields, query, displayRecordList);
-        } else {
+        if (typeof query === 'string') {
             _this.listRecords(settings.table, fields, query, displayRecordConfirmation);
+        } else {
+            _this.listRecords(settings.table, fields, query, displayRecordList);
         }
 
         function displayRecordList(result) {

--- a/package.json
+++ b/package.json
@@ -42,27 +42,35 @@
     "commands": [
       {
         "command": "sn_sync.syncTable",
-        "title": "Sync Table"
+        "title": "SNSync: Sync Table"
       },
       {
         "command": "sn_sync.enterConnectionSettings",
-        "title": "Connect To ServiceNow"
+        "title": "SNSync: Connect To ServiceNow"
       },
       {
         "command": "sn_sync.syncRecord",
-        "title": "Sync Record"
+        "title": "SNSync: Sync Record"
       },
       {
         "command": "sn_sync.syncMultipleRecords",
-        "title": "Sync Multiple Records"
+        "title": "SNSync: Sync Multiple Records"
       },
       {
         "command": "sn_sync.openRecordInBrowser",
-        "title": "Open Record In Browser"
+        "title": "SNSync: Open Record In Browser"
       },
       {
         "command": "sn_sync.compareFile",
-        "title": "Compare File To Server"
+        "title": "SNSync: Compare File To Server"
+      },
+      {
+        "command": "sn_sync.openEvalDocument",
+        "title": "SNSync: Open Empty Javascript File"
+      },
+      {
+        "command": "sn_sync.evalScript",
+        "title": "SNSync: Execute current file"
       }
     ]
   },
@@ -80,6 +88,7 @@
   "dependencies": {
     "diff": "^3.4.0",
     "glob": "^7.1.2",
+    "html2plaintext": "^2.0.1",
     "lodash": "^4.17.4",
     "opn": "^5.1.0",
     "request": "^2.83.0"


### PR DESCRIPTION
I already started with vscode extension to interact with Service-Now myself, I think it makes more sense if we work together at one cool vscode extension. So I added some code to execute a script server-side via the background script page. Have a look, try it out and let me now what you think about it :-)