### PR TITLE
Use html-to-text instead of html2plaintext package

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -7,7 +7,7 @@ const request = require('request');
 const jsdiff = require('diff');
 const glob = require('glob');
 const opn = require('opn');
-const html2plain = require('html2plaintext');
+const htmlToText = require('html-to-text');
 const sanitize = require("sanitize-filename");
 
 
@@ -187,7 +187,7 @@ var ServiceNowSync = (function () {
             _this._addProxy(evalOptions);
 
             request(evalOptions, function (error, response, body) {
-                cb(html2plain(body));
+                cb(htmlToText.fromString(body));
             });
         });
     };

--- a/extension.js
+++ b/extension.js
@@ -187,10 +187,20 @@ var ServiceNowSync = (function () {
             _this._addProxy(evalOptions);
 
             request(evalOptions, function (error, response, body) {
-                cb(htmlToText.fromString(body));
+                var text = htmlToText.fromString(parseBody(body), { wordwrap: false });
+                cb(text);
             });
         });
     };
+
+    function parseBody(body) {
+        var result = body
+            .replace('<HTML><BODY>', '')
+            .replace('<HR/>', '<BR/>')
+            .replace('<HR/><PRE>', '<PRE>\n---&gt;\n')
+            .replace('<BR/></PRE><HR/></BODY></HTML>', '\n&lt;---</PRE>');
+        return result;
+    }
 
     ServiceNowSync.prototype.updateScope = function () {
         var _this = this;
@@ -410,7 +420,7 @@ var ServiceNowSync = (function () {
         let _this = this;
 
         let quickPickOptions = _.map(tableFieldList, (obj, key) => {
-            if(key=='CapIO Suite'){
+            if (key == 'CapIO Suite') {
                 return {
                     detail: '⸌{◔◔}⸍ CapIO Automated Testing by Cerna Solutions',
                     label: key

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "servicenow-sync",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13,7 +13,8 @@
     "@types/node": {
       "version": "7.10.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.5.tgz",
-      "integrity": "sha512-RYkagUUbxQBss46ElbEa+j4q4X3GR12QwB7a/PM5hmVuVkYoW1jENT1+taspKUv8ibwW8cw+kRFbOaTc/Key3w=="
+      "integrity": "sha512-RYkagUUbxQBss46ElbEa+j4q4X3GR12QwB7a/PM5hmVuVkYoW1jENT1+taspKUv8ibwW8cw+kRFbOaTc/Key3w==",
+      "dev": true
     },
     "acorn": {
       "version": "5.7.3",
@@ -255,11 +256,6 @@
         "inherits": "~2.0.0"
       }
     },
-    "boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -349,19 +345,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
-    },
-    "cheerio": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
-      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
-      "requires": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.0",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash": "^4.15.0",
-        "parse5": "^3.0.1"
-      }
     },
     "circular-json": {
       "version": "0.3.3",
@@ -490,22 +473,6 @@
         "which": "^1.2.9"
       }
     },
-    "css-select": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "requires": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
-        "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
-      }
-    },
-    "css-what": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -567,12 +534,24 @@
       }
     },
     "dom-serializer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
+      "integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
       "requires": {
-        "domelementtype": "^1.3.0",
-        "entities": "^1.1.1"
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+        },
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+        }
       }
     },
     "domelementtype": {
@@ -589,9 +568,9 @@
       }
     },
     "domutils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
@@ -926,9 +905,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -1256,20 +1235,26 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
-    "html2plaintext": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/html2plaintext/-/html2plaintext-2.1.2.tgz",
-      "integrity": "sha512-/7rk161q0RFtQhu0F7oU7MFUtqjm2qBrVfoS8EOaHSdRNt72CNNYSV1/wN+TfO2GhgLQdIjPctmiWPX3oRcNFQ==",
+    "html-to-text": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-5.1.1.tgz",
+      "integrity": "sha512-Bci6bD/JIfZSvG4s0gW/9mMKwBRoe/1RWLxUME/d6WUSZCdY7T60bssf/jFf7EYXRyqU4P5xdClVqiYU0/ypdA==",
       "requires": {
-        "cheerio": "1.0.0-rc.2",
-        "he": "1.2.0",
-        "plumb": "0.1.0"
+        "he": "^1.2.0",
+        "htmlparser2": "^3.10.1",
+        "lodash": "^4.17.11",
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "he": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
           "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
@@ -1287,9 +1272,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -1502,9 +1487,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1583,9 +1568,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -1773,14 +1758,6 @@
         "once": "^1.3.2"
       }
     },
-    "nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "requires": {
-        "boolbase": "~1.0.0"
-      }
-    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -1864,14 +1841,6 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
-    "parse5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
@@ -1921,11 +1890,6 @@
         "arr-union": "^2.0.1",
         "extend-shallow": "^1.1.2"
       }
-    },
-    "plumb": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/plumb/-/plumb-0.1.0.tgz",
-      "integrity": "sha1-TFd5ClCWkoMv2/EN+t3XlIxctXQ="
     },
     "pluralize": {
       "version": "7.0.0",
@@ -2388,13 +2352,13 @@
       }
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,105 +1,105 @@
 {
-  "name": "servicenow-sync",
-  "author": "Sal Costa <costas0811@hotmail.com> (http://anerrantprogrammer.com",
-  "displayName": "ServiceNow Sync",
-  "description": "Sync records from ServiceNow to local files using VSC",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/salcosta/vsc-servicenow-sync.git"
-  },
-  "version": "0.2.3",
-  "license": "MIT",
-  "publisher": "anerrantprogrammer",
-  "engines": {
-    "vscode": "^1.18.0"
-  },
-  "categories": [
-    "Other"
-  ],
-  "activationEvents": [
-    "*"
-  ],
-  "main": "./extension",
-  "contributes": {
-    "menus": {
-      "explorer/context": [
-        {
-          "when": "explorerResourceIsFolder",
-          "command": "sn_sync.syncRecord"
-        },
-        {
-          "when": "explorerResourceIsFolder",
-          "command": "sn_sync.syncMultipleRecords"
-        },
-        {
-          "when": "!explorerResourceIsFolder",
-          "command": "sn_sync.compareFile"
-        }
-      ],
-      "editor/context": [
-        {
-          "command": "sn_sync.openRecordInBrowser",
-          "group": "z_commands"
-        }
-      ]
+    "name": "servicenow-sync",
+    "author": "Sal Costa <costas0811@hotmail.com> (http://anerrantprogrammer.com",
+    "displayName": "ServiceNow Sync",
+    "description": "Sync records from ServiceNow to local files using VSC",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/salcosta/vsc-servicenow-sync.git"
     },
-    "commands": [
-      {
-        "command": "sn_sync.syncTable",
-        "title": "SN Sync: Sync Table"
-      },
-      {
-        "command": "sn_sync.enterConnectionSettings",
-        "title": "SN Sync: Connect To ServiceNow"
-      },
-      {
-        "command": "sn_sync.enterProxySettings",
-        "title": "SN Sync: Enter Proxy Settings"
-      },
-      {
-        "command": "sn_sync.syncRecord",
-        "title": "SN Sync: Sync Record"
-      },
-      {
-        "command": "sn_sync.syncMultipleRecords",
-        "title": "SN Sync: Sync Multiple Records"
-      },
-      {
-        "command": "sn_sync.openRecordInBrowser",
-        "title": "SN Sync: Open Record In Browser"
-      },
-      {
-        "command": "sn_sync.updateScope",
-        "title": "SN Sync: Set Scope"
-      },
-      {
-        "command": "sn_sync.compareFile",
-        "title": "SN Sync: Compare File To Server"
-      },
-      {
-        "command": "sn_sync.evalScript",
-        "title": "SN Sync: Execute current file"
-      }
-    ]
-  },
-  "scripts": {
-    "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "node ./node_modules/vscode/bin/test"
-  },
-  "devDependencies": {
-    "typescript": "^2.6.1",
-    "vscode": "^1.1.6",
-    "eslint": "^4.6.1",
-    "@types/node": "^7.0.43",
-    "@types/mocha": "^2.2.42"
-  },
-  "dependencies": {
-    "diff": "^3.4.0",
-    "glob": "^7.1.2",
-    "html-to-text": "^5.1.1",
-    "lodash": "^4.17.15",
-    "opn": "^5.1.0",
-    "request": "^2.83.0",
-    "sanitize-filename": "^1.6.1"
-  }
+    "version": "0.2.4",
+    "license": "MIT",
+    "publisher": "anerrantprogrammer",
+    "engines": {
+        "vscode": "^1.18.0"
+    },
+    "categories": [
+        "Other"
+    ],
+    "activationEvents": [
+        "*"
+    ],
+    "main": "./extension",
+    "contributes": {
+        "menus": {
+            "explorer/context": [
+                {
+                    "when": "explorerResourceIsFolder",
+                    "command": "sn_sync.syncRecord"
+                },
+                {
+                    "when": "explorerResourceIsFolder",
+                    "command": "sn_sync.syncMultipleRecords"
+                },
+                {
+                    "when": "!explorerResourceIsFolder",
+                    "command": "sn_sync.compareFile"
+                }
+            ],
+            "editor/context": [
+                {
+                    "command": "sn_sync.openRecordInBrowser",
+                    "group": "z_commands"
+                }
+            ]
+        },
+        "commands": [
+            {
+                "command": "sn_sync.syncTable",
+                "title": "SN Sync: Sync Table"
+            },
+            {
+                "command": "sn_sync.enterConnectionSettings",
+                "title": "SN Sync: Connect To ServiceNow"
+            },
+            {
+                "command": "sn_sync.enterProxySettings",
+                "title": "SN Sync: Enter Proxy Settings"
+            },
+            {
+                "command": "sn_sync.syncRecord",
+                "title": "SN Sync: Sync Record"
+            },
+            {
+                "command": "sn_sync.syncMultipleRecords",
+                "title": "SN Sync: Sync Multiple Records"
+            },
+            {
+                "command": "sn_sync.openRecordInBrowser",
+                "title": "SN Sync: Open Record In Browser"
+            },
+            {
+                "command": "sn_sync.updateScope",
+                "title": "SN Sync: Set Scope"
+            },
+            {
+                "command": "sn_sync.compareFile",
+                "title": "SN Sync: Compare File To Server"
+            },
+            {
+                "command": "sn_sync.evalScript",
+                "title": "SN Sync: Execute current file"
+            }
+        ]
+    },
+    "scripts": {
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "test": "node ./node_modules/vscode/bin/test"
+    },
+    "devDependencies": {
+        "typescript": "^2.6.1",
+        "vscode": "^1.1.6",
+        "eslint": "^4.6.1",
+        "@types/node": "^7.0.43",
+        "@types/mocha": "^2.2.42"
+    },
+    "dependencies": {
+        "diff": "^3.4.0",
+        "glob": "^7.1.2",
+        "html-to-text": "^5.1.1",
+        "lodash": "^4.17.15",
+        "opn": "^5.1.0",
+        "request": "^2.83.0",
+        "sanitize-filename": "^1.6.1"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
         "command": "sn_sync.enterProxySettings",
         "title": "SN Sync: Enter Proxy Settings"
       },
-
       {
         "command": "sn_sync.syncRecord",
         "title": "SN Sync: Sync Record"
@@ -97,8 +96,8 @@
   "dependencies": {
     "diff": "^3.4.0",
     "glob": "^7.1.2",
-    "html2plaintext": "^2.0.1",
-    "lodash": "^4.17.4",
+    "html-to-text": "^5.1.1",
+    "lodash": "^4.17.15",
     "opn": "^5.1.0",
     "request": "^2.83.0",
     "sanitize-filename": "^1.6.1"


### PR DESCRIPTION
@salcosta, the html2plaintext package was not preserving PRE block in the scripts background response (for sn_sync.evalScript command). All new lines in the output were removed, which is not desirable. 

I swapped in a better package to convert html to text. It preserves the PRE block new lines. It also outputs the link for the execution history which can be useful if rollback is needed.

There were security vulnerabilities in a lodash dependency, so that's been upgraded as well.