### PR TITLE
Improve eval script output format

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -672,11 +672,14 @@ var ServiceNowSync = (function () {
       _this._addProxy(evalOptions);
 
       request(evalOptions, function (error, response, body) {
-        try{
-            cb(htmlToText(body));
-            } catch(e){
-                console.log(e);
-            }
+        cb(htmlToText((function (body) {
+            return body.replace('<HTML><BODY>', '')
+                .replace('<HR/>', '<BR/>')
+                .replace('<HR/><PRE>', '<PRE>\n---&gt;\n')
+                .replace('<BR/></PRE><HR/></BODY></HTML>', '\n&lt;---</PRE>');
+        })(body), {
+            wordwrap: false
+        }));
       });
     });
   };

--- a/extension.js
+++ b/extension.js
@@ -6,7 +6,7 @@ const _ = require("lodash");
 const request = require("request");
 const jsdiff = require("diff");
 const open = require("open");
-const html2plain = require("html2plaintext");
+const { htmlToText } = require('html-to-text');
 const sanitize = require("sanitize-filename");
 const tmp = require("tmp");
 const urlParse = require("url-parse");
@@ -672,7 +672,11 @@ var ServiceNowSync = (function () {
       _this._addProxy(evalOptions);
 
       request(evalOptions, function (error, response, body) {
-        cb(html2plain(body));
+        try{
+            cb(htmlToText(body));
+            } catch(e){
+                console.log(e);
+            }
       });
     });
   };

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
   },
   "dependencies": {
     "diff": "^3.4.0",
-    "html2plaintext": "^2.0.1",
+    "html-to-text": "^7.0.0",
     "lodash": "^4.17.4",
     "open": "^8.4.0",
     "request": "^2.83.0",


### PR DESCRIPTION
Hi salcosta, 

I'm proposing this PR which focuses on the evalScript output so that it can support line breaks (quite helpful when dumping stringified JSON objects for example). 

These are changes I've added a couple year ago on the "vsc-servicenow-sync-2021" fork, but seeing you're still maintaining this one, I guess it's worth adding those changes to your repository :)  
